### PR TITLE
fixed #430 Crash on crafting in Alchemy

### DIFF
--- a/source/gui/CraftPanel.cpp
+++ b/source/gui/CraftPanel.cpp
@@ -58,6 +58,9 @@ CraftPanel::CraftPanel()
 	button.parent = this;
 	button.id = GuiEvent_Custom;
 
+	lastListSize = 0;
+	lastListIndex = 0;
+
 	Add(&left);
 	Add(&right);
 }
@@ -217,10 +220,30 @@ void CraftPanel::Event(GuiEvent e)
 			else
 			{
 				list.Select(0);
+				lastListIndex = 0;
+				lastListSize = list.GetCount();
 				Recipe* recipe = static_cast<RecipeItem*>(list.GetItem())->recipe;
 				button.state = HaveIngredients(recipe) >= 1u ? Button::NONE : Button::DISABLED;
 			}
 			tooltip.Clear();
+		}
+	}
+	else if(e == GuiEvent_GainFocus)
+	{
+		if(list.GetItems().empty())
+				button.state = Button::DISABLED;
+		else
+		{
+			if (lastListSize > list.GetCount())
+			{
+				list.Select(0);
+				lastListIndex = 0;
+			}
+			else
+				list.Select(lastListIndex);
+
+			Recipe* recipe = static_cast<RecipeItem*>(list.GetItem())->recipe;
+			button.state = HaveIngredients(recipe) >= 1u ? Button::NONE : Button::DISABLED;
 		}
 	}
 	else if(e == GuiEvent_Hide)
@@ -230,6 +253,7 @@ void CraftPanel::Event(GuiEvent e)
 	}
 	else if(e == GuiEvent_Custom)
 	{
+		lastListIndex = list.GetIndex();
 		Recipe* recipe = static_cast<RecipeItem*>(list.GetItem())->recipe;
 		uint max = HaveIngredients(recipe);
 		counter = 1;

--- a/source/gui/CraftPanel.h
+++ b/source/gui/CraftPanel.h
@@ -30,6 +30,7 @@ private:
 
 	vector<pair<const Item*, uint>> ingredients;
 	int skill, counter;
+	uint lastListIndex, lastListSize;
 	GamePanel left, right;
 	ListBox list;
 	Button button;


### PR DESCRIPTION
Fixes #430 where recipe list in CraftPanel used to loose focus, while the craft button could still be pressed which resulted in crash. Now CraftPanel remembers last selected recipe index and restores it when gaining focus again. If the recipe list gets shorter (somehow) and last chosen index is past new size, index is set at 0.

Testing:
I was fiddling with crafting menu for a while. Recipe list did not lost focus. Craft button did not caused a crash.