### PR TITLE
Recipe learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.user
 
 .vs
+.vscode
 /bin
 /lib
 /other

--- a/source/entity/PlayerController.cpp
+++ b/source/entity/PlayerController.cpp
@@ -397,6 +397,11 @@ void PlayerController::Save(FileWriter& f)
 		for(Entity<Unit> unit : ability_targets)
 			f << unit;
 	}
+	f << recipes.size();
+	for(MemorizedRecipe& mr : recipes)
+	{
+		f << mr.recipe->hash;
+	}
 	f << split_gold;
 	f << always_run;
 	f << exp;
@@ -609,6 +614,44 @@ void PlayerController::Load(FileReader& f)
 		for(Entity<Unit>& unit : ability_targets)
 			f >> unit;
 	}
+
+	// recipes
+	if(LOAD_VERSION >= V_DEV)
+	{
+		uint count;
+		f >> count;
+		recipes.resize(count);
+		for(MemorizedRecipe& mr : recipes)
+		{
+			mr.recipe = Recipe::Get(f.Read<int>());
+		}
+	}
+	else
+	{
+		// Learn recipes based on player skill for saves before recipe learning
+		if (unit->Get(SkillId::ALCHEMY) >= 1)
+		{
+			Recipe* rcp_p_hp = Recipe::TryGet("p_hp");
+			Recipe* rcp_p_mp = Recipe::TryGet("p_mp");
+			AddRecipe(rcp_p_hp);
+			AddRecipe(rcp_p_mp);
+		}
+		if (unit->Get(SkillId::ALCHEMY) >= 25)
+		{
+			Recipe* rcp_p_hp = Recipe::TryGet("p_hp2");
+			Recipe* rcp_p_mp = Recipe::TryGet("p_mp2");
+			AddRecipe(rcp_p_hp);
+			AddRecipe(rcp_p_mp);
+		}
+		if (unit->Get(SkillId::ALCHEMY) >= 50)
+		{
+			Recipe* rcp_p_hp = Recipe::TryGet("p_hp3");
+			Recipe* rcp_p_mp = Recipe::TryGet("p_mp3");
+			AddRecipe(rcp_p_hp);
+			AddRecipe(rcp_p_mp);
+		}
+	}
+
 	if(LOAD_VERSION >= V_0_7)
 		f >> split_gold;
 	else
@@ -657,7 +700,7 @@ void PlayerController::Load(FileReader& f)
 	}
 	else
 		InitShortcuts();
-
+	
 	action = PlayerAction::None;
 }
 
@@ -1946,10 +1989,31 @@ void PlayerController::UseAbility(Ability* ability, bool from_server, const Vec3
 		data.ability_ready = nullptr;
 }
 
+bool PlayerController::AddRecipe(Recipe* recipe)
+{
+	if(HaveRecipe(recipe))
+		return false;
+	MemorizedRecipe mr;
+	mr.recipe = recipe;
+	recipes.push_back(mr);
+	return true;
+}
+
+bool PlayerController::HaveRecipe(Recipe* recipe) const
+{
+	assert(recipe);
+	for(const MemorizedRecipe& mr : recipes)
+	{
+		if(mr.recipe == recipe)
+			return true;
+	}
+	return false;
+}
+
 //=================================================================================================
 void PlayerController::Update(float dt)
 {
-	// licznik otrzymanych obra¿eñ
+	// licznik otrzymanych obraï¿½eï¿½
 	last_dmg = 0.f;
 	if(Net::IsLocal())
 		last_dmg_poison = 0.f;
@@ -2008,7 +2072,7 @@ void PlayerController::Update(float dt)
 			{
 				if(action_unit->IsAlive())
 				{
-					// grabiony cel o¿y³
+					// grabiony cel oï¿½yï¿½
 					game->CloseInventory();
 				}
 			}
@@ -2016,7 +2080,7 @@ void PlayerController::Update(float dt)
 			{
 				if(!action_unit->IsStanding() || !action_unit->IsIdle())
 				{
-					// handlarz umar³ / zaatakowany
+					// handlarz umarï¿½ / zaatakowany
 					game->CloseInventory();
 				}
 			}
@@ -2026,7 +2090,7 @@ void PlayerController::Update(float dt)
 			if(!game->dialog_context.talker->IsStanding() || !game->dialog_context.talker->IsIdle() || game->dialog_context.talker->to_remove
 				|| game->dialog_context.talker->frozen != FROZEN::NO)
 			{
-				// rozmówca umar³ / jest usuwany / zaatakowa³ kogoœ
+				// rozmï¿½wca umarï¿½ / jest usuwany / zaatakowaï¿½ kogoï¿½
 				game->dialog_context.EndDialog();
 			}
 		}
@@ -2235,7 +2299,7 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 
 			if(move)
 			{
-				// ustal k¹t i szybkoœæ ruchu
+				// ustal kï¿½t i szybkoï¿½ï¿½ ruchu
 				float angle = u.rot;
 				bool run = always_run;
 				if(u.action == A_ATTACK && u.act.attack.run)
@@ -2251,11 +2315,11 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 				float speed_mod;
 				switch(move)
 				{
-				case 10: // przód
+				case 10: // przï¿½d
 					angle += PI;
 					speed_mod = 1.f;
 					break;
-				case -10: // ty³
+				case -10: // tyï¿½
 					run = false;
 					speed_mod = 0.8f;
 					break;
@@ -2267,20 +2331,20 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 					angle += PI * 3 / 2;
 					speed_mod = 0.75f;
 					break;
-				case 9: // lewa góra
+				case 9: // lewa gï¿½ra
 					angle += PI * 3 / 4;
 					speed_mod = 0.9f;
 					break;
-				case 11: // prawa góra
+				case 11: // prawa gï¿½ra
 					angle += PI * 5 / 4;
 					speed_mod = 0.9f;
 					break;
-				case -11: // lewy ty³
+				case -11: // lewy tyï¿½
 					run = false;
 					angle += PI / 4;
 					speed_mod = 0.9f;
 					break;
-				case -9: // prawy ty³
+				case -9: // prawy tyï¿½
 					run = false;
 					angle += PI * 7 / 4;
 					speed_mod = 0.9f;
@@ -2602,21 +2666,21 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 		{
 			Unit* u2 = data.before_player_ptr.unit;
 
-			// przed graczem jest jakaœ postaæ
+			// przed graczem jest jakaï¿½ postaï¿½
 			if(u2->live_state == Unit::DEAD || u2->live_state == Unit::FALL)
 			{
-				// grabienie zw³ok
+				// grabienie zwï¿½ok
 				if(u.action != A_NONE)
 				{
 				}
 				else if(u2->live_state == Unit::FALL)
 				{
-					// nie mo¿na okradaæ osoby która zaraz wstanie
+					// nie moï¿½na okradaï¿½ osoby ktï¿½ra zaraz wstanie
 					game_gui->messages->AddGameMsg3(GMS_CANT_DO);
 				}
 				else if(u2->IsFollower() || u2->IsPlayer())
 				{
-					// nie mo¿na okradaæ sojuszników
+					// nie moï¿½na okradaï¿½ sojusznikï¿½w
 					game_gui->messages->AddGameMsg3(GMS_DONT_LOOT_FOLLOWER);
 				}
 				else if(u2->in_arena != -1)
@@ -2625,12 +2689,12 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 				{
 					if(Net::IsOnline() && u2->busy == Unit::Busy_Looted)
 					{
-						// ktoœ ju¿ ograbia zw³oki
+						// ktoï¿½ juï¿½ ograbia zwï¿½oki
 						game_gui->messages->AddGameMsg3(GMS_IS_LOOTED);
 					}
 					else
 					{
-						// rozpoczynij wymianê przedmiotów
+						// rozpoczynij wymianï¿½ przedmiotï¿½w
 						action = PlayerAction::LootUnit;
 						action_unit = u2;
 						u2->busy = Unit::Busy_Looted;
@@ -2640,7 +2704,7 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 				}
 				else
 				{
-					// wiadomoœæ o wymianie do serwera
+					// wiadomoï¿½ï¿½ o wymianie do serwera
 					NetChange& c = Add1(Net::changes);
 					c.type = NetChange::LOOT_UNIT;
 					c.id = u2->id;
@@ -2655,19 +2719,19 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 				{
 					if(u2->busy != Unit::Busy_No || !u2->CanTalk(u))
 					{
-						// osoba jest czymœ zajêta
+						// osoba jest czymï¿½ zajï¿½ta
 						game_gui->messages->AddGameMsg3(GMS_UNIT_BUSY);
 					}
 					else
 					{
-						// rozpocznij rozmowê
+						// rozpocznij rozmowï¿½
 						game->dialog_context.StartDialog(u2);
 						data.before_player = BP_NONE;
 					}
 				}
 				else
 				{
-					// wiadomoœæ o rozmowie do serwera
+					// wiadomoï¿½ï¿½ o rozmowie do serwera
 					NetChange& c = Add1(Net::changes);
 					c.type = NetChange::TALK;
 					c.id = u2->id;
@@ -2679,7 +2743,7 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 		}
 		else if(data.before_player == BP_CHEST)
 		{
-			// pl¹drowanie skrzyni
+			// plï¿½drowanie skrzyni
 			if(u.action != A_NONE)
 			{
 			}
@@ -2691,7 +2755,7 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 			}
 			else
 			{
-				// wyœlij wiadomoœæ o pl¹drowaniu skrzyni
+				// wyï¿½lij wiadomoï¿½ï¿½ o plï¿½drowaniu skrzyni
 				NetChange& c = Add1(Net::changes);
 				c.type = NetChange::USE_CHEST;
 				c.id = data.before_player_ptr.chest->id;
@@ -2746,7 +2810,7 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 		}
 		else if(data.before_player == BP_ITEM)
 		{
-			// podnieœ przedmiot
+			// podnieï¿½ przedmiot
 			GroundItem& item = *data.before_player_ptr.item;
 			if(u.action == A_NONE)
 			{
@@ -3156,7 +3220,7 @@ void PlayerController::UpdateMove(float dt, bool allow_rot)
 			case -11: // left backward
 				data.ability_rot = -PI * 3 / 4;
 				break;
-			case -9: // prawy ty³
+			case -9: // prawy tyï¿½
 				data.ability_rot = PI * 3 / 4;
 				break;
 			}

--- a/source/entity/PlayerController.h
+++ b/source/entity/PlayerController.h
@@ -119,6 +119,15 @@ struct PlayerAbility
 	int charges;
 };
 
+/**
+ * Represents recipe known to the player
+ */
+struct MemorizedRecipe
+{
+	Recipe* recipe;
+};
+
+
 //-----------------------------------------------------------------------------
 struct Shortcut
 {
@@ -237,16 +246,17 @@ struct PlayerController : public HeroPlayerCommon
 		Chest* action_chest;
 		Usable* action_usable;
 	};
-	// tymczasowa zmienna u¿ywane w AddGold, nie trzeba zapisywaæ
+	// tymczasowa zmienna uï¿½ywane w AddGold, nie trzeba zapisywaï¿½
 	int gold_get;
 	//
 	DialogContext* dialog_ctx;
-	vector<ItemSlot>* chest_trade; // zale¿ne od action (dla LootUnit,ShareItems,GiveItems ekw jednostki, dla LootChest zawartoœæ skrzyni, dla Trade skrzynia kupca)
+	vector<ItemSlot>* chest_trade; // zaleï¿½ne od action (dla LootUnit,ShareItems,GiveItems ekw jednostki, dla LootChest zawartoï¿½ï¿½ skrzyni, dla Trade skrzynia kupca)
 	int kills, dmg_done, dmg_taken, knocks, arena_fights, stat_flags;
 	vector<TakenPerk> perks;
 	vector<Entity<Unit>> ability_targets;
 	Shortcut shortcuts[Shortcut::MAX];
 	vector<PlayerAbility> abilities;
+	vector<MemorizedRecipe> recipes;
 	static LocalPlayerData data;
 
 	PlayerController() : dialog_ctx(nullptr), stat_flags(0), player_info(nullptr), is_local(false), last_ring(false) {}
@@ -323,6 +333,10 @@ public:
 	void UpdateCooldown(float dt);
 	void RefreshCooldown();
 	void UseAbility(Ability* ability, bool from_server, const Vec3* pos_data = nullptr, Unit* target = nullptr);
+
+	// recipes
+	bool AddRecipe(Recipe* recipe);
+	bool HaveRecipe(Recipe* recipe) const;
 
 	void AddLearningPoint(int count = 1);
 	void AddExp(int exp);

--- a/source/gui/CraftPanel.cpp
+++ b/source/gui/CraftPanel.cpp
@@ -202,7 +202,6 @@ void CraftPanel::Event(GuiEvent e)
 			left.Event(GuiEvent_Show);
 			right.Event(GuiEvent_Show);
 
-			skill = game->pc->unit->Get(SkillId::ALCHEMY);
 			SetRecipes();
 			SetIngredients();
 			if(list.GetItems().empty())
@@ -248,13 +247,10 @@ void CraftPanel::Event(GuiEvent e)
 void CraftPanel::SetRecipes()
 {
 	list.Reset();
-	for(Recipe* recipe : Recipe::recipes)
+	for(MemorizedRecipe& recipe : game->pc->recipes)
 	{
-		if(skill >= recipe->skill)
-		{
-			RecipeItem* item = new RecipeItem(recipe);
-			list.Add(item);
-		}
+		RecipeItem* item = new RecipeItem(recipe.recipe);
+		list.Add(item);
 	}
 }
 
@@ -363,12 +359,7 @@ void CraftPanel::AfterCraft()
 	SetIngredients();
 	button.state = HaveIngredients(recipe) >= 1u ? Button::NONE : Button::DISABLED;
 
-	int new_skill = game->pc->unit->Get(SkillId::ALCHEMY);
-	if(skill != new_skill)
-	{
-		skill = new_skill;
-		int index = list.GetIndex();
-		SetRecipes();
-		list.SetIndex(index);
-	}
+	int index = list.GetIndex();
+	SetRecipes();
+	list.SetIndex(index);
 }

--- a/source/gui/CraftPanel.h
+++ b/source/gui/CraftPanel.h
@@ -29,7 +29,7 @@ private:
 	uint HaveIngredients(Recipe* recipe);
 
 	vector<pair<const Item*, uint>> ingredients;
-	int skill, counter;
+	int counter;
 	GamePanel left, right;
 	ListBox list;
 	Button button;

--- a/source/gui/Inventory.cpp
+++ b/source/gui/Inventory.cpp
@@ -21,8 +21,8 @@
 /* UWAGI CO DO ZMIENNYCH
 index - indeks do items [0, 1, 2, 3...]
 t_index - indeks to tmp_inv [0, 1, 2, 3...]
-i_index - wartoœæ dla t_index (dla ujemnych slot) [-1, -2, -3, 0, 1, 2, 3...]
-i_index == index dla nie za³o¿onych przedmiotów
+i_index - wartoï¿½ï¿½ dla t_index (dla ujemnych slot) [-1, -2, -3, 0, 1, 2, 3...]
+i_index == index dla nie zaï¿½oï¿½onych przedmiotï¿½w
 
 last_index to tutaj t_index
 */
@@ -271,7 +271,7 @@ void Inventory::StartTrade2(InventoryMode mode, void* ptr)
 }
 
 //=================================================================================================
-// zbuduj tymczasowy ekwipunek który ³¹czy slots i items postaci
+// zbuduj tymczasowy ekwipunek ktï¿½ry ï¿½ï¿½czy slots i items postaci
 void Inventory::BuildTmpInventory(int index)
 {
 	assert(index == 0 || index == 1);
@@ -303,7 +303,7 @@ void Inventory::BuildTmpInventory(int index)
 
 	ids.clear();
 
-	// jeœli to postaæ to dodaj za³o¿one przedmioty
+	// jeï¿½li to postaï¿½ to dodaj zaï¿½oï¿½one przedmioty
 	if(slots)
 	{
 		for(int i = 0; i < SLOT_MAX; ++i)
@@ -316,7 +316,7 @@ void Inventory::BuildTmpInventory(int index)
 		}
 	}
 
-	// nie za³o¿one przedmioty
+	// nie zaï¿½oï¿½one przedmioty
 	for(int i = 0, count = (int)items->size(); i < count; ++i)
 		ids.push_back(i);
 }
@@ -360,7 +360,7 @@ void InventoryPanel::Draw(ControlDrawData*)
 	// scrollbar
 	scrollbar.Draw();
 
-	// miejsce na z³oto i udŸwig
+	// miejsce na zï¿½oto i udï¿½wig
 	int bar_size = (cells_w * 63 - 8) / 2;
 	int bar_y = shift_y + cells_h * 63 + 8;
 	float load = 0.f;
@@ -374,7 +374,7 @@ void InventoryPanel::Draw(ControlDrawData*)
 	else if(mode == LOOT_OTHER)
 		bt.Draw();
 
-	// napis u góry
+	// napis u gï¿½ry
 	Rect rect = {
 		pos.x,
 		pos.y + 10,
@@ -385,14 +385,14 @@ void InventoryPanel::Draw(ControlDrawData*)
 
 	if(mode != TRADE_OTHER && mode != LOOT_OTHER)
 	{
-		// ikona z³ota
+		// ikona zï¿½ota
 		gui->DrawSprite(base.tGold, Int2(shift_x, bar_y));
 
-		// z³oto
+		// zï¿½oto
 		rect = Rect::Create(Int2(shift_x, bar_y), Int2(bar_size, 32));
 		gui->DrawText(GameGui::font, Format("%d", unit->gold), DTF_CENTER | DTF_VCENTER, Color::Black, rect);
 
-		// udŸwig
+		// udï¿½wig
 		rect.Left() = shift_x + bar_size + 10;
 		rect.Right() = rect.Left() + bar_size;
 		cstring weight_str = Format(base.txCarryShort, float(unit->weight) / 10, float(unit->weight_max) / 10);
@@ -578,7 +578,7 @@ void InventoryPanel::Update(float dt)
 		int bar_size = (cells_w * 63 - 8) / 2;
 		int bar_y = shift_y + cells_h * 63 + 8;
 
-		// pasek ze z³otem lub udŸwigiem
+		// pasek ze zï¿½otem lub udï¿½wigiem
 		if(mode != TRADE_OTHER && mode != LOOT_OTHER)
 		{
 			if(cursor_pos.y >= bar_y && cursor_pos.y < bar_y + 32)
@@ -598,7 +598,7 @@ void InventoryPanel::Update(float dt)
 		}
 	}
 
-	// klawisz do podnoszenia wszystkich przedmiotów
+	// klawisz do podnoszenia wszystkich przedmiotï¿½w
 	if(mode == LOOT_OTHER && (focus || base.inv_trade_mine->focus) && input->Focus() && GKey.PressedRelease(GK_TAKE_ALL))
 	{
 		Event(GuiEvent_Custom);
@@ -679,10 +679,10 @@ void InventoryPanel::Update(float dt)
 		if(!focus || !(game->pc->unit->action == A_NONE || game->pc->unit->CanDoWhileUsing()) || base.lock || !input->Focus() || !game->pc->unit->IsStanding())
 			return;
 
-		// obs³uga kilkania w ekwipunku
+		// obsï¿½uga kilkania w ekwipunku
 		if(mode == INVENTORY && input->PressedRelease(Key::RightButton) && game->pc->unit->action == A_NONE)
 		{
-			// wyrzuæ przedmiot
+			// wyrzuï¿½ przedmiot
 			if(IsSet(item->flags, ITEM_DONT_DROP) && team->IsAnyoneTalking())
 				gui->SimpleDialog(base.txCantDoNow, this);
 			else
@@ -705,7 +705,7 @@ void InventoryPanel::Update(float dt)
 				{
 					if(input->Down(Key::Shift))
 					{
-						// wyrzuæ wszystkie
+						// wyrzuï¿½ wszystkie
 						unit->DropItems(i_index, 0);
 						last_index = INDEX_INVALID;
 						if(mode == INVENTORY)
@@ -715,7 +715,7 @@ void InventoryPanel::Update(float dt)
 					}
 					else if(input->Down(Key::Control) || slot->count == 1)
 					{
-						// wyrzuæ jeden
+						// wyrzuï¿½ jeden
 						if(unit->DropItem(i_index))
 						{
 							base.BuildTmpInventory(0);
@@ -729,7 +729,7 @@ void InventoryPanel::Update(float dt)
 					}
 					else
 					{
-						// wyrzuæ okreœlon¹ liczbê
+						// wyrzuï¿½ okreï¿½lonï¿½ liczbï¿½
 						counter = 1;
 						base.lock.Lock(i_index, *slot);
 						base.lock_dialog = GetNumberDialog::Show(this, delegate<void(int)>(this, &InventoryPanel::OnDropItem), base.txDropItemCount, 1, slot->count, &counter);
@@ -798,7 +798,7 @@ void InventoryPanel::Update(float dt)
 						}
 						else
 						{
-							// sprawdŸ czy mo¿na u¿ywaæ
+							// sprawdï¿½ czy moï¿½na uï¿½ywaï¿½
 							bool ok = true;
 							if(type == SLOT_ARMOR)
 							{
@@ -821,7 +821,7 @@ void InventoryPanel::Update(float dt)
 					gui->SimpleDialog(base.txWontBuy, this);
 				else if(!slot)
 				{
-					// za³o¿ony przedmiot
+					// zaï¿½oï¿½ony przedmiot
 					if(unit->SlotRequireHideWeapon(slot_type))
 					{
 						// hide equipped item and sell it
@@ -834,8 +834,8 @@ void InventoryPanel::Update(float dt)
 				}
 				else
 				{
-					// nie za³o¿ony przedmiot
-					// ustal ile gracz chce sprzedaæ przedmiotów
+					// nie zaï¿½oï¿½ony przedmiot
+					// ustal ile gracz chce sprzedaï¿½ przedmiotï¿½w
 					uint count;
 					if(item->IsStackable() && slot->count != 1)
 					{
@@ -863,7 +863,7 @@ void InventoryPanel::Update(float dt)
 			case TRADE_OTHER:
 				// buying items
 				{
-					// ustal ile gracz chce kupiæ przedmiotów
+					// ustal ile gracz chce kupiï¿½ przedmiotï¿½w
 					uint count;
 					if(item->IsStackable() && slot->count != 1)
 					{
@@ -892,7 +892,7 @@ void InventoryPanel::Update(float dt)
 				// put item into corpse/chest/container
 				if(slot)
 				{
-					// nie za³o¿ony przedmiot
+					// nie zaï¿½oï¿½ony przedmiot
 					uint count;
 					if(item->IsStackable() && slot->count != 1)
 					{
@@ -918,7 +918,7 @@ void InventoryPanel::Update(float dt)
 				}
 				else
 				{
-					// za³o¿ony przedmiot
+					// zaï¿½oï¿½ony przedmiot
 					if(unit->SlotRequireHideWeapon(slot_type))
 					{
 						// hide equipped item and put it in container
@@ -934,7 +934,7 @@ void InventoryPanel::Update(float dt)
 				// take item from corpse/chest/container
 				if(slot)
 				{
-					// nie za³o¿ony przedmiot
+					// nie zaï¿½oï¿½ony przedmiot
 					uint count;
 					if(item->IsStackable() && slot->count != 1)
 					{
@@ -979,12 +979,12 @@ void InventoryPanel::Update(float dt)
 				}
 				else
 				{
-					// za³o¿ony przedmiot
+					// zaï¿½oï¿½ony przedmiot
 					last_index = INDEX_INVALID;
 					// dodaj
 					game->pc->unit->AddItem(item, 1u, 1u);
 					base.BuildTmpInventory(0);
-					// usuñ
+					// usuï¿½
 					if(slot_type == SLOT_WEAPON && slots[SLOT_WEAPON] == unit->used_item)
 					{
 						unit->used_item = nullptr;
@@ -1000,7 +1000,7 @@ void InventoryPanel::Update(float dt)
 					unit->weight -= item->weight;
 					slots[slot_type] = nullptr;
 					base.BuildTmpInventory(1);
-					// dŸwiêk
+					// dï¿½wiï¿½k
 					sound_mgr->PlaySound2d(game_res->GetItemSound(item));
 					// komunikat
 					if(Net::IsOnline())
@@ -1029,7 +1029,7 @@ void InventoryPanel::Update(float dt)
 				// give item to companion to store
 				if(slot && slot->team_count > 0)
 				{
-					// nie za³o¿ony przedmiot
+					// nie zaï¿½oï¿½ony przedmiot
 					uint count;
 					if(item->IsStackable() && slot->team_count != 1)
 					{
@@ -1069,7 +1069,7 @@ void InventoryPanel::Update(float dt)
 				// take item from companion
 				if(slot && slot->team_count > 0)
 				{
-					// nie za³o¿ony przedmiot
+					// nie zaï¿½oï¿½ony przedmiot
 					uint count;
 					if(item->IsStackable() && slot->team_count != 1)
 					{
@@ -1107,7 +1107,7 @@ void InventoryPanel::Update(float dt)
 				Unit* t = unit->player->action_unit;
 				if(slot)
 				{
-					// nie za³o¿ony przedmiot
+					// nie zaï¿½oï¿½ony przedmiot
 					if(t->CanWear(item))
 					{
 						last_index = INDEX_INVALID;
@@ -1199,7 +1199,7 @@ void InventoryPanel::Update(float dt)
 					{
 						if(t->IsBetterItem(item))
 						{
-							// za³o¿ony przedmiot
+							// zaï¿½oï¿½ony przedmiot
 							if(t->CanTake(item))
 							{
 								if(unit->SlotRequireHideWeapon(slot_type))
@@ -1238,7 +1238,7 @@ void InventoryPanel::Update(float dt)
 	}
 	else if(new_index == INDEX_GOLD && mode != GIVE_OTHER && mode != SHARE_OTHER && !base.lock && game->pc->unit->IsStanding() && game->pc->unit->action == A_NONE)
 	{
-		// wyrzucanie/chowanie/dawanie z³ota
+		// wyrzucanie/chowanie/dawanie zï¿½ota
 		if(input->PressedRelease(Key::LeftButton))
 		{
 			last_index = INDEX_INVALID;
@@ -1399,7 +1399,7 @@ void InventoryPanel::Event(GuiEvent e)
 }
 
 //=================================================================================================
-// przek³ada przedmiot ze slotu do ekwipunku
+// przekï¿½ada przedmiot ze slotu do ekwipunku
 void InventoryPanel::RemoveSlotItem(ITEM_SLOT slot)
 {
 	const Item* item = slots[slot];
@@ -1764,22 +1764,22 @@ void InventoryPanel::BuyItem(int index, uint count)
 
 	if(price > game->pc->unit->gold)
 	{
-		// gracz ma za ma³o z³ota
+		// gracz ma za maï¿½o zï¿½ota
 		gui->SimpleDialog(Format(base.txNeedMoreGoldItem, price - game->pc->unit->gold, slot.item->name.c_str()), this);
 	}
 	else
 	{
-		// dŸwiêk
+		// dï¿½wiï¿½k
 		sound_mgr->PlaySound2d(game_res->GetItemSound(slot.item));
 		sound_mgr->PlaySound2d(game_res->sCoins);
-		// usuñ z³oto
+		// usuï¿½ zï¿½oto
 		game->pc->unit->gold -= price;
 		if(Net::IsLocal())
 			game->pc->Train(TrainWhat::Trade, (float)price, 0);
 		// dodaj przedmiot graczowi
 		if(!game->pc->unit->AddItem(slot.item, count, 0u))
 			UpdateGrid(true);
-		// usuñ przedmiot sprzedawcy
+		// usuï¿½ przedmiot sprzedawcy
 		slot.count -= count;
 		if(slot.count == 0)
 		{
@@ -1809,10 +1809,10 @@ void InventoryPanel::SellItem(int index, uint count)
 	uint team_count = min(count, slot.team_count);
 	uint normal_count = count - team_count;
 
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(slot.item));
 	sound_mgr->PlaySound2d(game_res->sCoins);
-	// dodaj z³oto
+	// dodaj zï¿½oto
 	if(Net::IsLocal())
 	{
 		int price = ItemHelper::GetItemPrice(slot.item, *game->pc->unit, false);
@@ -1825,7 +1825,7 @@ void InventoryPanel::SellItem(int index, uint count)
 	// dodaj przedmiot kupcowi
 	if(!InsertItem(*unit->player->chest_trade, slot.item, count, team_count))
 		UpdateGrid(false);
-	// usuñ przedmiot graczowi
+	// usuï¿½ przedmiot graczowi
 	unit->weight -= slot.item->weight*count;
 	slot.count -= count;
 	if(slot.count == 0)
@@ -1856,10 +1856,10 @@ void InventoryPanel::SellSlotItem(ITEM_SLOT slot)
 {
 	const Item* item = slots[slot];
 
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(item));
 	sound_mgr->PlaySound2d(game_res->sCoins);
-	// dodaj z³oto
+	// dodaj zï¿½oto
 	int price = ItemHelper::GetItemPrice(item, *game->pc->unit, false);
 	unit->gold += price;
 	if(Net::IsLocal())
@@ -1867,7 +1867,7 @@ void InventoryPanel::SellSlotItem(ITEM_SLOT slot)
 	// dodaj przedmiot kupcowi
 	InsertItem(*unit->player->chest_trade, item, 1, 0);
 	UpdateGrid(false);
-	// usuñ przedmiot graczowi
+	// usuï¿½ przedmiot graczowi
 	if(Net::IsLocal())
 		unit->RemoveItemEffects(item, slot);
 	slots[slot] = nullptr;
@@ -1906,12 +1906,12 @@ void InventoryPanel::OnPutGold(int id)
 			gui->SimpleDialog(base.txDropNoGold, this);
 			return;
 		}
-		// dodaj z³oto
+		// dodaj zï¿½oto
 		if(!InsertItem(*unit->player->chest_trade, Item::gold, counter, 0))
 			UpdateGrid(false);
-		// usuñ
+		// usuï¿½
 		unit->gold -= counter;
-		// dŸwiêk
+		// dï¿½wiï¿½k
 		sound_mgr->PlaySound2d(game_res->sCoins);
 		if(!Net::IsLocal())
 		{
@@ -1935,12 +1935,12 @@ void InventoryPanel::LootItem(int index, uint count)
 {
 	ItemSlot& slot = items->at(index);
 	uint team_count = min(count, slot.team_count);
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(slot.item));
 	// dodaj
 	if(!game->pc->unit->AddItem(slot.item, count, team_count))
 		UpdateGrid(true);
-	// usuñ
+	// usuï¿½
 	if(base.mode == I_LOOT_BODY)
 	{
 		unit->weight -= slot.item->weight*count;
@@ -2165,7 +2165,7 @@ void InventoryPanel::ShareGiveItem(int index, uint count)
 	ItemSlot& slot = items->at(index);
 	const Item* item = slot.item;
 	uint team_count = min(count, slot.team_count);
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(slot.item));
 	// dodaj
 	if(!unit->player->action_unit->AddItem(slot.item, count, team_count))
@@ -2178,7 +2178,7 @@ void InventoryPanel::ShareGiveItem(int index, uint count)
 		else if(pot.ai_type == ConsumableAiType::Mana)
 			unit->player->action_unit->ai->have_mp_potion = HavePotion::Yes;
 	}
-	// usuñ
+	// usuï¿½
 	unit->weight -= slot.item->weight*count;
 	slot.count -= count;
 	if(slot.count == 0)
@@ -2210,7 +2210,7 @@ void InventoryPanel::ShareTakeItem(int index, uint count)
 	ItemSlot& slot = items->at(index);
 	const Item* item = slot.item;
 	uint team_count = min(count, slot.team_count);
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(slot.item));
 	// dodaj
 	if(!game->pc->unit->AddItem(slot.item, count, team_count))
@@ -2223,7 +2223,7 @@ void InventoryPanel::ShareTakeItem(int index, uint count)
 		else if(pot.ai_type == ConsumableAiType::Mana)
 			unit->ai->have_mp_potion = HavePotion::Check;
 	}
-	// usuñ
+	// usuï¿½
 	unit->weight -= slot.item->weight*count;
 	slot.count -= count;
 	if(slot.count == 0)
@@ -2298,9 +2298,9 @@ void InventoryPanel::OnGiveItem(int id)
 	}
 	t->AddItem(item, 1u, 0u);
 	UpdateGrid(false);
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(item));
-	// usuñ
+	// usuï¿½
 	unit->weight -= item->weight;
 	if(slot)
 		items->erase(items->begin() + iindex);
@@ -2353,7 +2353,7 @@ void InventoryPanel::GivePotion(int index, uint count)
 {
 	ItemSlot& slot = items->at(index);
 	uint team_count = min(count, slot.team_count);
-	// dŸwiêk
+	// dï¿½wiï¿½k
 	sound_mgr->PlaySound2d(game_res->GetItemSound(slot.item));
 	// dodaj
 	if(!unit->player->action_unit->AddItem(slot.item, count, 0u))
@@ -2366,7 +2366,7 @@ void InventoryPanel::GivePotion(int index, uint count)
 		else if(pot.ai_type == ConsumableAiType::Mana)
 			unit->player->action_unit->ai->have_mp_potion = HavePotion::Yes;
 	}
-	// usuñ
+	// usuï¿½
 	unit->weight -= slot.item->weight*count;
 	slot.count -= count;
 	if(slot.count == 0)
@@ -2408,7 +2408,7 @@ void InventoryPanel::GiveSlotItem(ITEM_SLOT slot)
 	}
 	else
 	{
-		// zaproponuj inn¹ cenê
+		// zaproponuj innï¿½ cenï¿½
 		info.text = Format(base.txSellFreeItem, item->value / 2);
 		give_item_mode = 2;
 	}
@@ -2537,6 +2537,11 @@ void InventoryPanel::UpdateGrid(bool mine)
 void InventoryPanel::ReadBook(const Item* item, int index)
 {
 	assert(item && item->type == IT_BOOK);
+	// Book contains a recipes, so learn them
+	for(Recipe* r : ((const Book*)item)->recipes)
+	{
+		game->pc->AddRecipe(r);
+	}
 	if(IsSet(item->flags, ITEM_MAGIC_SCROLL))
 	{
 		if(!game->pc->unit->usable) // can't use when sitting

--- a/source/net/NetChangePlayer.h
+++ b/source/net/NetChangePlayer.h
@@ -53,6 +53,7 @@ struct NetChangePlayer
 		ADD_ABILITY, // add ability to player [int(ability->hash)]
 		REMOVE_ABILITY, // remove ability from player [int(ability->hash)]
 		AFTER_CRAFT, // after crafting - update ingredients, play sound
+		ADD_RECIPE, // add recipe to player [int(recipe->hash)]
 
 		MAX
 	} type;
@@ -63,6 +64,7 @@ struct NetChangePlayer
 		Unit* unit;
 		string* str;
 		Ability* ability;
+		Recipe* recipe;
 		struct
 		{
 			short a1, a2;

--- a/source/net/NetClient.cpp
+++ b/source/net/NetClient.cpp
@@ -234,7 +234,7 @@ void Net::UpdateClient(float dt)
 		}
 	}
 
-	// wyœli moj¹ pozycjê/akcjê
+	// wyï¿½li mojï¿½ pozycjï¿½/akcjï¿½
 	update_timer += dt;
 	if(update_timer >= TICK)
 	{
@@ -4013,6 +4013,23 @@ bool Net::ProcessControlMessageClientForMe(BitStreamReader& f)
 		// after crafting - update ingredients, play sound
 		case NetChangePlayer::AFTER_CRAFT:
 			game_gui->craft->AfterCraft();
+			break;
+		// add recipe to player
+		case NetChangePlayer::ADD_RECIPE:
+			{
+				int recipe_hash;
+				f >> recipe_hash;
+				if(!f)
+				{
+					Error("Update single client: Broken ADD_RECIPE.");
+					break;
+				}
+				Recipe* recipe = Recipe::Get(recipe_hash);
+				if(!recipe)
+					Error("Update single client: ADD_RECIPE, invalid recipe %u.", recipe_hash);
+				else
+					pc.AddRecipe(recipe);
+			}
 			break;
 		default:
 			Warn("Update single client: Unknown player change type %d.", type);

--- a/source/net/NetServer.cpp
+++ b/source/net/NetServer.cpp
@@ -119,7 +119,7 @@ void Net::OnNewGameServer()
 	game_level->can_fast_travel = false;
 	warps.clear();
 	if(!mp_load)
-		changes.clear(); // przy wczytywaniu jest czyszczone przed wczytaniem i w net_changes s¹ zapisane quest_items
+		changes.clear(); // przy wczytywaniu jest czyszczone przed wczytaniem i w net_changes sï¿½ zapisane quest_items
 	if(!net_strs.empty())
 		StringPool.Free(net_strs);
 	game_gui->server->max_players = max_players;
@@ -242,7 +242,7 @@ void Net::UpdateServer(float dt)
 				ServerProcessUnits(area.units);
 		}
 
-		// wyœlij odkryte kawa³ki minimapy
+		// wyï¿½lij odkryte kawaï¿½ki minimapy
 		if(!game_level->minimap_reveal_mp.empty())
 		{
 			if(game->game_state == GS_LEVEL)
@@ -4014,6 +4014,9 @@ void Net::WriteServerChangesForPlayer(BitStreamWriter& f, PlayerInfo& info)
 		case NetChangePlayer::REMOVE_ABILITY:
 			f << c.ability->hash;
 			break;
+		case NetChangePlayer::ADD_RECIPE:
+			f << c.recipe->hash;
+			break;
 		default:
 			Error("Update server: Unknown player %s change %d.", info.name.c_str(), c.type);
 			assert(0);
@@ -4034,13 +4037,13 @@ void Net::Server_Say(BitStreamReader& f, PlayerInfo& info)
 		Error("Server_Say: Broken packet from %s: %s.", info.name.c_str());
 	else
 	{
-		// id gracza jest ignorowane przez serwer ale mo¿na je sprawdziæ
+		// id gracza jest ignorowane przez serwer ale moï¿½na je sprawdziï¿½
 		assert(id == info.id);
 
 		cstring str = Format("%s: %s", info.name.c_str(), text.c_str());
 		game_gui->AddMsg(str);
 
-		// przeœlij dalej
+		// przeï¿½lij dalej
 		if(active_players > 2)
 			peer->Send(&f.GetBitStream(), MEDIUM_PRIORITY, RELIABLE, 0, info.adr, true);
 
@@ -4061,13 +4064,13 @@ void Net::Server_Whisper(BitStreamReader& f, PlayerInfo& info)
 	{
 		if(id == team->my_id)
 		{
-			// wiadomoœæ do mnie
+			// wiadomoï¿½ï¿½ do mnie
 			cstring str = Format("%s@: %s", info.name.c_str(), text.c_str());
 			game_gui->AddMsg(str);
 		}
 		else
 		{
-			// wiadomoœæ do kogoœ innego
+			// wiadomoï¿½ï¿½ do kogoï¿½ innego
 			PlayerInfo* info2 = TryGetPlayer(id);
 			if(!info2)
 				Error("Server_Whisper: Broken packet from %s to missing player %d.", info.name.c_str(), id);
@@ -4171,6 +4174,7 @@ bool Net::FilterOut(NetChangePlayer& c)
 	case NetChangePlayer::GAME_MESSAGE_FORMATTED:
 	case NetChangePlayer::ADD_ABILITY:
 	case NetChangePlayer::REMOVE_ABILITY:
+	case NetChangePlayer::ADD_RECIPE:
 		return false;
 	default:
 		return true;

--- a/source/script/ScriptManager.cpp
+++ b/source/script/ScriptManager.cpp
@@ -673,6 +673,10 @@ void ScriptManager::RegisterGame()
 		.WithNamespace()
 		.AddFunction("Ability@ Get(const string& in)", asFUNCTION(Ability::GetS));
 
+	AddType("Recipe")
+		.WithNamespace()
+		.AddFunction("Recipe@ Get(const string& in)", asFUNCTION(Recipe::GetS));
+
 	AddType("UnitData")
 		.WithNamespace()
 		.AddFunction("UnitData@ Get(const string& in)", asFUNCTION(UnitData::GetS));
@@ -755,6 +759,7 @@ void ScriptManager::RegisterGame()
 		.Method("bool IsLeader()", asMETHOD(PlayerController, IsLeader))
 		.Method("bool AddAbility(Ability@)", asMETHOD(PlayerController, AddAbility))
 		.Method("bool RemoveAbility(Ability@)", asMETHOD(PlayerController, RemoveAbility))
+		.Method("bool AddRecipe(Recipe@)", asMETHOD(PlayerController, AddRecipe))
 		.WithInstance("Player@ pc", &ctx.pc);
 
 	ForType("Hero")

--- a/source/system/Item.cpp
+++ b/source/system/Item.cpp
@@ -25,7 +25,7 @@ vector<BookScheme*> BookScheme::book_schemes;
 vector<Book*> Book::books;
 vector<StartItem> StartItem::start_items;
 std::map<const Item*, Item*> better_items;
-vector<Recipe*> Recipe::recipes;
+std::map<int, Recipe*> Recipe::hash_recipes;
 
 //-----------------------------------------------------------------------------
 // adding new types here will require changes in CreatedCharacter::GetStartingItems
@@ -509,12 +509,18 @@ const Item* FindItemOrList(Cstring id, ItemList*& lis)
 }
 
 //=================================================================================================
-Recipe* Recipe::TryGet(Cstring id)
+Recipe* Recipe::Get(int hash)
 {
-	for(Recipe* recipe : Recipe::recipes)
-	{
-		if(recipe->id == id)
-			return recipe;
-	}
+	auto it = hash_recipes.find(hash);
+	if(it != hash_recipes.end())
+		return it->second;
 	return nullptr;
+}
+
+Recipe* Recipe::GetS(const string& id)
+{
+	Recipe* recipe = TryGet(id);
+	if (!recipe)
+		throw ScriptException("Invalid recipe '%s'.", id);
+	return recipe;
 }

--- a/source/system/Item.h
+++ b/source/system/Item.h
@@ -485,6 +485,7 @@ struct StartItem
 //-----------------------------------------------------------------------------
 struct Recipe
 {
+	int hash;
 	string id;
 	const Item* result;
 	vector<pair<const Item*, uint>> items;
@@ -492,8 +493,10 @@ struct Recipe
 
 	explicit Recipe() : result(nullptr), skill(0) {}
 
-	static vector<Recipe*> recipes;
-	static Recipe* TryGet(Cstring id);
+	static std::map<int, Recipe*> hash_recipes;
+	static Recipe* Get(int hash);
+	static Recipe* TryGet(Cstring id) { return Get(Hash(id)); }
+	static Recipe* GetS(const string& id);
 };
 
 //-----------------------------------------------------------------------------

--- a/source/system/Item.h
+++ b/source/system/Item.h
@@ -420,6 +420,8 @@ struct Book : public Item
 	Book() : Item(IT_BOOK), scheme(nullptr), runic(false) {}
 
 	BookScheme* scheme;
+	vector<string> recipe_ids;
+	vector<Recipe*> recipes;
 	string text;
 	bool runic;
 
@@ -491,7 +493,7 @@ struct Recipe
 	vector<pair<const Item*, uint>> items;
 	int skill;
 
-	explicit Recipe() : result(nullptr), skill(0) {}
+	explicit Recipe() : hash(0), result(nullptr), skill(0) {}
 
 	static std::map<int, Recipe*> hash_recipes;
 	static Recipe* Get(int hash);


### PR DESCRIPTION
Character now stores known recipes. It is possible to memorize new recipe using script command or reading a book with recipes tag. CraftPanel shows only recipes which are known to the character. Memorized recipes are kept in save file. If loading old save file, prior to recipe learning, character will memorize recipes that he had available before recipe learning implementation.

Testing:
Created character, scripted in a recipe, saw it was available in CraftPanel. Saved and reloaded and recipes known at save time appeared in CraftPanel. Tried an old save and saw that recipes the player had available back then are memorized properly and available for crafting. Learned a recipe in multiplayer as both client and server. Created a Book item with *recipes* tag. Reading the book added the recipes included.

Additional context:
Using/balancing the new recipe learning mechanics in-game is not subject of this PR.

Edit:
I changed this PR's meaning, so if there are any problems with it, I will try to resolve them.